### PR TITLE
Enable auto greyscale detection in watch mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A powerful tool for converting CBZ/CBR comic archives to WebP format, focusing o
 - Customizable WebP compression parameters
 - Support for presets to quickly apply optimized settings
 - Directory watching mode to automatically process new files
+- Optional automatic greyscale detection (works in watch mode)
 - Detailed statistics tracking for optimization results
 - Support for batch processing
 

--- a/cbxtools/watchers.py
+++ b/cbxtools/watchers.py
@@ -4,6 +4,7 @@ Watch mode logic for CBZ/CBR/CB7 to WebP converter.
 Reserves one thread for CBZ packaging and uses the rest for image conversion.
 Supports recursive directory watching and preserves source directory structure.
 Now supports watching for new images and image folders.
+Automatic greyscale detection is applied when enabled.
 """
 
 import time
@@ -219,6 +220,13 @@ def watch_directory(input_dir, output_dir, args, logger, stats_tracker=None):
         logger.info(f"Image transformations: grayscale={args.grayscale}")
     if args.auto_contrast:
         logger.info(f"Image transformations: auto_contrast={args.auto_contrast}")
+    if getattr(args, 'auto_greyscale', False):
+        pixel_thresh = getattr(args, 'auto_greyscale_pixel_threshold', 16)
+        percent_thresh = getattr(args, 'auto_greyscale_percent_threshold', 0.01)
+        logger.info(
+            "Image transformations: auto_greyscale=%s (pixel_threshold=%s, percent_threshold=%s)"
+            % (args.auto_greyscale, pixel_thresh, percent_thresh)
+        )
     logger.info("Press Ctrl+C to stop watching")
 
     processed_files = set()
@@ -414,7 +422,18 @@ def watch_directory(input_dir, output_dir, args, logger, stats_tracker=None):
                         zip_compresslevel=args.zip_compression,
                         lossless=args.lossless,
                         grayscale=args.grayscale,
-                        auto_contrast=args.auto_contrast
+                        auto_contrast=args.auto_contrast,
+                        auto_greyscale=getattr(args, 'auto_greyscale', False),
+                        auto_greyscale_pixel_threshold=getattr(
+                            args,
+                            'auto_greyscale_pixel_threshold',
+                            16,
+                        ),
+                        auto_greyscale_percent_threshold=getattr(
+                            args,
+                            'auto_greyscale_percent_threshold',
+                            0.01,
+                        ),
                     )
 
                     if success:


### PR DESCRIPTION
## Summary
- support automatic greyscale detection when running in `--watch` mode
- log auto-greyscale parameters in watch mode
- update README feature list

## Testing
- `python -m py_compile cbxtools/watchers.py`
- `python -m py_compile cbxtools/cli.py`
- `python -m py_compile cbxtools/*.py`


------
https://chatgpt.com/codex/tasks/task_e_687af989bf4883338c0a1143928def41