### PR TITLE
Enable auto greyscale detection in watch mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,17 @@ A powerful tool for converting CBZ/CBR comic archives to WebP format, focusing o
 
 ## Features
 
-- Convert CBZ/CBR comic archives to WebP-based CBZ files
+- Convert CBZ, CBR and CB7 archives (ZIP/RAR/7z) to WebP-based CBZ files
+- Process individual images and entire folders
 - Preserve metadata and all non-image files from the original archives
-- Significantly reduce file sizes (typically 30-70%)
-- Multi-threaded processing for fast conversion
-- Customizable WebP compression parameters
-- Support for presets to quickly apply optimized settings
-- Directory watching mode to automatically process new files
-- Detailed statistics tracking for optimization results
+- Multi-threaded conversion with optional asynchronous packaging
+- Customizable WebP compression parameters and preprocessing filters
+- Manual grayscale and auto-contrast options
+- Optional automatic greyscale detection with configurable thresholds (works in watch mode)
+- Directory watching mode to automatically process new archives, images and image folders
+- Built-in dependency checker with optional automatic installation
+- Persistent lifetime statistics tracking and detailed reports
+- Debug utilities for analysing greyscale detection
 - Support for batch processing
 
 ## Installation
@@ -100,15 +103,11 @@ cbxtools input_path output_dir [options]
 CBXTools includes several built-in presets optimized for different types of content:
 
 - `default`: Balanced settings for most comic types
-- `comic`: Optimized for comic books with text and line art
-- `photo`: Better quality for photorealistic images
+- `comic`: Optimized for comic books with line art and text
+- `photo`: Higher quality for photographic images
 - `maximum_compression`: Maximum compression (lower quality)
-- `maximum_quality`: Highest quality with lossless compression
-- `phone_friendly`: Sized for mobile devices
-- `manga`: Optimized for manga content
-- `e_ink`: Optimized for e-ink readers with enhanced contrast
-- `fast_conversion`: Fastest processing with acceptable quality
-- `tiny`: Maximum compression with size limits
+- `maximum_quality`: Highest quality with optional lossless compression
+- `manga`: Optimized for manga content with aggressive greyscale detection
 
 You can view available presets with:
 

--- a/WATCH_MODE.md
+++ b/WATCH_MODE.md
@@ -1,0 +1,15 @@
+# Watch Mode
+
+CBXTools can monitor an input directory and automatically process new files as they appear.
+
+## Key Features
+
+- Detects new CBZ, CBR and CB7 archives as well as loose images or entire image folders
+- Preserves the original directory structure in the output folder
+- Uses a dedicated packaging thread so image conversion and CBZ creation run concurrently
+- Maintains a history file to avoid re-processing files between sessions
+- Optional deletion of originals once conversion succeeds
+- Works with all transformation options including automatic greyscale detection and presets
+- Lifetime statistics are updated as items are processed
+
+Use `--watch` with any normal conversion options. Combine with `--delete-originals` to clean up the source directory automatically.

--- a/cbxtools/watchers.py
+++ b/cbxtools/watchers.py
@@ -4,6 +4,7 @@ Watch mode logic for CBZ/CBR/CB7 to WebP converter.
 Reserves one thread for CBZ packaging and uses the rest for image conversion.
 Supports recursive directory watching and preserves source directory structure.
 Now supports watching for new images and image folders.
+Automatic greyscale detection is applied when enabled.
 """
 
 import time
@@ -219,6 +220,13 @@ def watch_directory(input_dir, output_dir, args, logger, stats_tracker=None):
         logger.info(f"Image transformations: grayscale={args.grayscale}")
     if args.auto_contrast:
         logger.info(f"Image transformations: auto_contrast={args.auto_contrast}")
+    if getattr(args, 'auto_greyscale', False):
+        pixel_thresh = getattr(args, 'auto_greyscale_pixel_threshold', 16)
+        percent_thresh = getattr(args, 'auto_greyscale_percent_threshold', 0.01)
+        logger.info(
+            "Image transformations: auto_greyscale=%s (pixel_threshold=%s, percent_threshold=%s)"
+            % (args.auto_greyscale, pixel_thresh, percent_thresh)
+        )
     logger.info("Press Ctrl+C to stop watching")
 
     processed_files = set()
@@ -414,7 +422,18 @@ def watch_directory(input_dir, output_dir, args, logger, stats_tracker=None):
                         zip_compresslevel=args.zip_compression,
                         lossless=args.lossless,
                         grayscale=args.grayscale,
-                        auto_contrast=args.auto_contrast
+                        auto_contrast=args.auto_contrast,
+                        auto_greyscale=getattr(args, 'auto_greyscale', False),
+                        auto_greyscale_pixel_threshold=getattr(
+                            args,
+                            'auto_greyscale_pixel_threshold',
+                            16,
+                        ),
+                        auto_greyscale_percent_threshold=getattr(
+                            args,
+                            'auto_greyscale_percent_threshold',
+                            0.01,
+                        ),
                     )
 
                     if success:

--- a/presets-readme.md
+++ b/presets-readme.md
@@ -23,11 +23,11 @@ cbxtools input.cbz output/ --preset comic --quality 90
 The system comes with several built-in presets:
 
 - **default**: Balanced settings for most use cases
-- **comic**: Optimized for comic books with text and line art
+- **comic**: Optimized for comic books with line art and text
 - **photo**: Higher quality for photographic content
 - **maximum_compression**: Prioritizes file size reduction
-- **maximum_quality**: Highest quality with lossless compression
-- **phone_friendly**: Sized for mobile devices
+- **maximum_quality**: Highest quality with optional lossless compression
+- **manga**: Optimized for manga content with aggressive greyscale detection
 
 ## Managing Presets
 


### PR DESCRIPTION
## Summary
- support automatic greyscale detection when running in `--watch` mode
- log auto-greyscale parameters in watch mode
- update README feature list and preset names
- clarify presets in presets-readme
- document watch mode capabilities

## Testing
- `python -m py_compile cbxtools/watchers.py`
- `python -m py_compile cbxtools/cli.py`
- `python -m py_compile cbxtools/*.py`


------
https://chatgpt.com/codex/tasks/task_e_687af989bf4883338c0a1143928def41