### PR TITLE
Add near greyscale scan mode

### DIFF
--- a/cbxtools/cli.py
+++ b/cbxtools/cli.py
@@ -8,6 +8,7 @@ import sys
 import time
 import argparse
 import subprocess
+import shutil
 from pathlib import Path
 
 from .utils import setup_logging, remove_empty_dirs, log_effective_parameters
@@ -329,6 +330,12 @@ def parse_arguments():
                         help='Test multiple threshold combinations on a single image and exit')
     debug_group.add_argument('--debug-analyze-directory', type=str, metavar='DIRECTORY_PATH',
                         help='Analyze all images in directory with current thresholds and exit')
+
+    scan_group = parser.add_argument_group('Near Greyscale Scan')
+    scan_group.add_argument('--scan-near-greyscale', choices=['dryrun','move','process'],
+                        help='Scan archives for near-greyscale images and take action')
+    scan_group.add_argument('--scan-output', type=str, default=None,
+                        help='Output file for dryrun or destination directory for move mode')
     
     # Dependency management options
     dep_group = parser.add_argument_group('Dependency Management Options')
@@ -554,6 +561,60 @@ def handle_debug_operations(args, logger):
     return None
 
 
+def handle_scan_near_greyscale(input_path, args, logger):
+    """Scan archives for near greyscale images and take the requested action."""
+    from .near_greyscale_scan import scan_directory_for_near_greyscale
+    pixel_threshold = getattr(args, 'auto_greyscale_pixel_threshold', 16)
+    percent_threshold = getattr(args, 'auto_greyscale_percent_threshold', 0.01)
+
+    archives = scan_directory_for_near_greyscale(
+        input_path,
+        args.recursive,
+        pixel_threshold,
+        percent_threshold,
+        logger,
+    )
+
+    if args.scan_near_greyscale == 'dryrun':
+        list_file = Path(args.scan_output or 'near_greyscale_list.txt')
+        with open(list_file, 'w') as f:
+            for a in archives:
+                f.write(str(a) + '\n')
+        logger.info(f"Listed {len(archives)} archives to {list_file}")
+        return 0
+
+    if args.scan_near_greyscale == 'move':
+        if not args.scan_output:
+            logger.error("--scan-output is required for move mode")
+            return 1
+        dest_dir = Path(args.scan_output).resolve()
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        moved = 0
+        for a in archives:
+            target = dest_dir / a.name
+            shutil.move(str(a), target)
+            logger.info(f"Moved {a} -> {target}")
+            moved += 1
+        logger.info(f"Moved {moved} archives")
+        return 0
+
+    if args.scan_near_greyscale == 'process':
+        processed = 0
+        for a in archives:
+            success, _, _ = process_single_archive_file(a, a.parent, args, logger)
+            if success and a.suffix.lower() != '.cbz':
+                try:
+                    a.unlink()
+                except Exception as e:
+                    logger.error(f"Failed to delete {a}: {e}")
+            if success:
+                processed += 1
+        logger.info(f"Processed {processed} archives")
+        return 0 if processed == len(archives) else 1
+
+    return 0
+
+
 def handle_watch_mode(input_path, output_dir, args, logger, stats_tracker):
     """Handle watch mode operation."""
     # Watch mode requires an input directory
@@ -772,6 +833,9 @@ def main():
     
     # Log the effective parameters being used
     log_effective_parameters(args, logger, args.recursive)
+
+    if args.scan_near_greyscale:
+        return handle_scan_near_greyscale(input_path, args, logger)
     
     # Handle watch mode
     if args.watch:

--- a/cbxtools/near_greyscale_scan.py
+++ b/cbxtools/near_greyscale_scan.py
@@ -1,0 +1,61 @@
+"""Utilities for scanning archives for near greyscale images."""
+
+from pathlib import Path
+import os
+import tempfile
+
+from PIL import Image
+import numpy as np
+
+from .archives import extract_archive, find_comic_archives
+from .conversion import should_convert_to_greyscale
+
+
+IMAGE_EXTS = {'.jpg', '.jpeg', '.png', '.gif', '.bmp', '.tiff', '.webp'}
+
+
+def archive_contains_near_greyscale(archive_path, pixel_threshold=16, percent_threshold=0.01, logger=None):
+    """Return True if any image in the archive would be converted to greyscale."""
+    archive_path = Path(archive_path)
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir)
+        try:
+            extract_archive(archive_path, temp_path, logger)
+        except Exception as e:
+            if logger:
+                logger.error(f"Error extracting {archive_path}: {e}")
+            return False
+
+        for root, _, files in os.walk(temp_path):
+            for file in files:
+                img_path = Path(root) / file
+                if img_path.suffix.lower() in IMAGE_EXTS:
+                    try:
+                        with Image.open(img_path) as img:
+                            if img.mode not in ('RGB', 'RGBA'):
+                                continue
+                            img_array = np.array(img)
+                            if should_convert_to_greyscale(img_array, pixel_threshold, percent_threshold):
+                                return True
+                    except Exception as e:
+                        if logger:
+                            logger.warning(f"Failed to analyze {img_path}: {e}")
+                        continue
+    return False
+
+
+def scan_directory_for_near_greyscale(directory, recursive=False, pixel_threshold=16, percent_threshold=0.01, logger=None):
+    """Return a list of archives that contain near greyscale images."""
+    directory = Path(directory)
+    archives = find_comic_archives(directory, recursive)
+    results = []
+    for archive in archives:
+        if logger:
+            logger.info(f"Scanning {archive} for near greyscale images")
+        try:
+            if archive_contains_near_greyscale(archive, pixel_threshold, percent_threshold, logger):
+                results.append(archive)
+        except Exception as e:
+            if logger:
+                logger.error(f"Error scanning {archive}: {e}")
+    return results


### PR DESCRIPTION
## Summary
- add module `near_greyscale_scan` to find archives containing images which would be auto-greyscaled
- extend CLI with `--scan-near-greyscale` and `--scan-output` options
- implement `handle_scan_near_greyscale` and invoke it from `main`

## Testing
- `python -m py_compile cbxtools/cli.py cbxtools/near_greyscale_scan.py`

------
https://chatgpt.com/codex/tasks/task_e_687b0b49bfe8833398870fb270ab2dc2