### PR TITLE
Improve near greyscale dryrun output handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ cbxtools input_path output_dir [options]
 ### Near Greyscale Scan Options
 
 - `--scan-near-greyscale {dryrun,move,process}`: Scan archives for near-grey images and optionally move or process them
-- `--scan-output PATH`: Output file for dryrun or destination directory for move mode
+- `--scan-output PATH`: Output file for dryrun or destination directory for move mode. If PATH is a directory in dryrun mode, `near_greyscale_list.txt` will be created in that directory. When omitted, the list is written to `near_greyscale_list.txt` in the current directory.
 Scanning respects the `--threads` option for parallel processing.
 
 ### Watch Mode Options
@@ -161,6 +161,14 @@ Show lifetime statistics:
 ```bash
 cbxtools --stats-only
 ```
+
+Scan a directory for near-greyscale archives without moving them:
+
+```bash
+cbxtools --scan-near-greyscale dryrun --scan-output "D:\Manga Backup" D:\Manga
+```
+
+This creates `near_greyscale_list.txt` inside `D:\Manga Backup`.
 
 ## Metadata Preservation
 

--- a/cbxtools/cli.py
+++ b/cbxtools/cli.py
@@ -590,7 +590,14 @@ def handle_scan_near_greyscale(input_path, args, logger):
     )
 
     if args.scan_near_greyscale == 'dryrun':
-        list_file = Path(args.scan_output or 'near_greyscale_list.txt')
+        if args.scan_output:
+            candidate = Path(args.scan_output)
+            if candidate.exists() and candidate.is_dir():
+                list_file = candidate / 'near_greyscale_list.txt'
+            else:
+                list_file = candidate
+        else:
+            list_file = Path('near_greyscale_list.txt')
         with open(list_file, 'w') as f:
             for a, near, total in results:
                 f.write(f"{a}\t{near}/{total}\n")


### PR DESCRIPTION
## Summary
- support directory paths for `--scan-output` in dryrun mode
- clarify README options and add usage example

## Testing
- `python -m py_compile cbxtools/*.py`

------
https://chatgpt.com/codex/tasks/task_e_687c55e5af9483338a6813f667743cb8