### PR TITLE
Fix encoding and improve grey scale scan

### DIFF
--- a/cbxtools/cli.py
+++ b/cbxtools/cli.py
@@ -580,15 +580,7 @@ def handle_scan_near_greyscale(input_path, args, logger):
     percent_threshold = getattr(args, 'auto_greyscale_percent_threshold', 0.01)
     threads = args.threads if args.threads != 0 else os.cpu_count() or 1
 
-    results = scan_directory_for_near_greyscale(
-        input_path,
-        args.recursive,
-        pixel_threshold,
-        percent_threshold,
-        threads,
-        logger,
-    )
-
+    list_file = None
     if args.scan_near_greyscale == 'dryrun':
         if args.scan_output:
             candidate = Path(args.scan_output)
@@ -598,10 +590,22 @@ def handle_scan_near_greyscale(input_path, args, logger):
                 list_file = candidate
         else:
             list_file = Path('near_greyscale_list.txt')
-        with open(list_file, 'w') as f:
-            for a, near, total in results:
-                f.write(f"{a}\t{near}/{total}\n")
-        logger.info(f"Listed {len(results)} archives to {list_file}")
+
+    results, output_path = scan_directory_for_near_greyscale(
+        input_path,
+        args.recursive,
+        pixel_threshold,
+        percent_threshold,
+        threads,
+        logger,
+        list_file,
+    )
+
+    if args.scan_near_greyscale == 'dryrun':
+        for a, near, total in results:
+            logger.info(f"{a}\t{near}/{total}")
+        if output_path:
+            logger.info(f"Listed {len(results)} archives to {output_path}")
         return 0
 
     if args.scan_near_greyscale == 'move':

--- a/cbxtools/debug_utils.py
+++ b/cbxtools/debug_utils.py
@@ -102,7 +102,7 @@ def save_debug_analysis(image_path, analysis, output_dir, logger):
     }
     
     try:
-        with open(debug_file, 'w') as f:
+        with open(debug_file, 'w', encoding='utf-8') as f:
             json.dump(debug_data, f, indent=2)
         logger.debug(f"Saved debug analysis to {debug_file}")
     except Exception as e:
@@ -336,7 +336,7 @@ def debug_archive_greyscale(archive_path, output_dir=None,
                                 'analysis': analysis
                             }
                             
-                            with open(img_debug_file, 'w') as f:
+                            with open(img_debug_file, 'w', encoding='utf-8') as f:
                                 json.dump(debug_data, f, indent=2)
                             
                             # Create visualization for this image
@@ -417,7 +417,7 @@ def debug_archive_greyscale(archive_path, output_dir=None,
                 }
                 
                 summary_file = archive_debug_dir / 'archive_analysis_summary.json'
-                with open(summary_file, 'w') as f:
+                with open(summary_file, 'w', encoding='utf-8') as f:
                     json.dump(summary, f, indent=2)
                 
                 logger.info(f"\nDetailed analysis saved to: {archive_debug_dir}")
@@ -614,7 +614,7 @@ def test_threshold_ranges(image_path, output_dir=None, logger=None):
     
     # Save results
     results_file = output_dir / f"{image_path.stem}_threshold_test_results.json"
-    with open(results_file, 'w') as f:
+    with open(results_file, 'w', encoding='utf-8') as f:
         json.dump(results, f, indent=2)
     
     logger.info(f"\nDetailed results saved to: {results_file}")
@@ -778,7 +778,7 @@ def analyze_directory_for_auto_greyscale(directory_path, pixel_threshold=16,
         
         summary_file = directory_path / 'debug_batch' / 'batch_analysis_summary.json'
         summary_file.parent.mkdir(exist_ok=True)
-        with open(summary_file, 'w') as f:
+        with open(summary_file, 'w', encoding='utf-8') as f:
             json.dump(summary, f, indent=2)
         
         logger.info(f"Detailed summary saved to: {summary_file}")

--- a/cbxtools/presets.py
+++ b/cbxtools/presets.py
@@ -41,7 +41,7 @@ def load_default_presets():
     
     if default_path and default_path.exists():
         try:
-            with open(default_path, 'r') as f:
+            with open(default_path, 'r', encoding='utf-8') as f:
                 return json.load(f)
         except (json.JSONDecodeError, IOError) as e:
             logging.warning(f"Could not load default presets from {default_path}: {e}")
@@ -70,7 +70,7 @@ def ensure_preset_file():
     # If preset file doesn't exist, create it with default presets
     if not DEFAULT_PRESET_FILE.exists():
         default_presets = load_default_presets()
-        with open(DEFAULT_PRESET_FILE, 'w') as f:
+        with open(DEFAULT_PRESET_FILE, 'w', encoding='utf-8') as f:
             json.dump(default_presets, f, indent=2)
         _PRESETS_CACHE = default_presets.copy()
         return DEFAULT_PRESET_FILE
@@ -78,7 +78,7 @@ def ensure_preset_file():
     # Load existing presets if not already cached
     if _PRESETS_CACHE is None:
         try:
-            with open(DEFAULT_PRESET_FILE, 'r') as f:
+            with open(DEFAULT_PRESET_FILE, 'r', encoding='utf-8') as f:
                 _PRESETS_CACHE = json.load(f)
         except (json.JSONDecodeError, IOError) as e:
             # If there's an error with the file, use defaults and don't overwrite
@@ -120,7 +120,7 @@ def save_preset(name, parameters, overwrite=False, logger=None):
         _PRESETS_CACHE[name] = parameters
         
         # Write updated cache to file
-        with open(DEFAULT_PRESET_FILE, 'w') as f:
+        with open(DEFAULT_PRESET_FILE, 'w', encoding='utf-8') as f:
             json.dump(_PRESETS_CACHE, f, indent=2)
             
         if logger:
@@ -155,7 +155,7 @@ def import_presets_from_file(file_path, overwrite=False, logger=None):
     
     try:
         # Load presets from the file
-        with open(file_path, 'r') as f:
+        with open(file_path, 'r', encoding='utf-8') as f:
             imported_presets = json.load(f)
             
         if not isinstance(imported_presets, dict):
@@ -173,7 +173,7 @@ def import_presets_from_file(file_path, overwrite=False, logger=None):
                 import_count += 1
                 
         # Save merged presets
-        with open(DEFAULT_PRESET_FILE, 'w') as f:
+        with open(DEFAULT_PRESET_FILE, 'w', encoding='utf-8') as f:
             json.dump(_PRESETS_CACHE, f, indent=2)
             
         if logger:

--- a/cbxtools/stats_tracker.py
+++ b/cbxtools/stats_tracker.py
@@ -24,7 +24,7 @@ class StatsTracker:
     def _load_stats(self):
         if self.stats_file.exists():
             try:
-                with open(self.stats_file, 'r') as f:
+                with open(self.stats_file, 'r', encoding='utf-8') as f:
                     return json.load(f)
             except (json.JSONDecodeError, IOError) as e:
                 print(f"Warning: Could not load stats file: {e}", file=sys.stderr)
@@ -47,7 +47,7 @@ class StatsTracker:
     def save_stats(self):
         try:
             self.stats_file.parent.mkdir(parents=True, exist_ok=True)
-            with open(self.stats_file, 'w') as f:
+            with open(self.stats_file, 'w', encoding='utf-8') as f:
                 json.dump(self.stats, f, indent=2)
         except IOError as e:
             print(f"Warning: Could not save stats file: {e}", file=sys.stderr)

--- a/cbxtools/watchers.py
+++ b/cbxtools/watchers.py
@@ -235,7 +235,7 @@ def watch_directory(input_dir, output_dir, args, logger, stats_tracker=None):
     # Load history file if it exists
     if history_file.exists():
         try:
-            with open(history_file, 'r') as f:
+            with open(history_file, 'r', encoding='utf-8') as f:
                 history_data = json.load(f)
                 processed_paths = history_data.get('processed_files', [])
                 processed_files = set(Path(p) for p in processed_paths)
@@ -251,7 +251,7 @@ def watch_directory(input_dir, output_dir, args, logger, stats_tracker=None):
                 'processed_files': [str(p) for p in processed_files],
                 'last_updated': datetime.datetime.now().isoformat()
             }
-            with open(history_file, 'w') as f:
+            with open(history_file, 'w', encoding='utf-8') as f:
                 json.dump(history_data, f, indent=2)
             logger.debug(f"Saved {len(processed_files)} processed items to history")
         except Exception as e:

--- a/tests/test_unicode_paths.py
+++ b/tests/test_unicode_paths.py
@@ -1,0 +1,13 @@
+import json
+from pathlib import Path
+from cbxtools.stats_tracker import StatsTracker
+
+
+def test_stats_tracker_unicode_path(tmp_path):
+    file_path = tmp_path / "данные.json"
+    tracker = StatsTracker(file_path)
+    tracker.add_run(1, 100, 50, 1.0)
+    assert file_path.exists()
+    tracker2 = StatsTracker(file_path)
+    assert tracker2.stats["run_count"] == 1
+


### PR DESCRIPTION
## Summary
- specify UTF-8 when reading/writing stats, presets and watcher history
- capture near greyscale scan results as they happen
- log scan details to console
- add test ensuring unicode filenames work with StatsTracker

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d1add36008333967a62dfa345ee16