### PR TITLE
Fix near greyscale scan logic

### DIFF
--- a/cbxtools/near_greyscale_scan.py
+++ b/cbxtools/near_greyscale_scan.py
@@ -16,7 +16,7 @@ import numpy as np
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from .archives import extract_archive, find_comic_archives
-from .conversion import should_convert_to_greyscale
+from .conversion import should_convert_to_greyscale, analyze_image_colorfulness
 
 
 IMAGE_EXTS = {'.jpg', '.jpeg', '.png', '.gif', '.bmp', '.tiff', '.webp'}
@@ -51,7 +51,10 @@ def archive_contains_near_greyscale(archive_path, pixel_threshold=16, percent_th
                                 continue
                             total_count += 1
                             img_array = np.array(img)
-                            if should_convert_to_greyscale(img_array, pixel_threshold, percent_threshold):
+                            _, _, colored_ratio = analyze_image_colorfulness(
+                                img_array, pixel_threshold
+                            )
+                            if 0 < colored_ratio <= percent_threshold:
                                 near_count += 1
                     except Exception as e:
                         if logger:


### PR DESCRIPTION
## Summary
- avoid counting true greyscale images as near-greyscale
- import `analyze_image_colorfulness` for ratio checks

## Testing
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687d2e10e71083339750c5e3e61a2e44