### PR TITLE
Fix stats tracker path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -224,7 +224,7 @@ Each preset can configure:
 
 ### User Configuration
 - Presets stored in `~/.cbxtools/presets.json`
-- Statistics stored in `~/.cbxtools/.cbx-tools-stats.json`
+ - Statistics stored in `~/.cbx-tools-stats.json`
 - Watch mode history in output directory
 
 ### Debug Parameter Resolution

--- a/cbxtools/stats_tracker.py
+++ b/cbxtools/stats_tracker.py
@@ -16,7 +16,7 @@ class StatsTracker:
     
     def __init__(self, stats_file=None):
         if stats_file is None:
-            self.stats_file = Path.home() / '.cbxtools//.cbx-tools-stats.json'
+            self.stats_file = Path.home() / '.cbx-tools-stats.json'
         else:
             self.stats_file = Path(stats_file)
         self.stats = self._load_stats()


### PR DESCRIPTION
## Summary
- adjust default stats file path
- document new stats file location in AGENTS

## Testing
- `pytest -q tests/test_unicode_paths.py`

------
https://chatgpt.com/codex/tasks/task_e_687eb211459483339989699753827c76