### PR TITLE
Fix watcher worker loop and import

### DIFF
--- a/test_refactoring.py
+++ b/test_refactoring.py
@@ -186,7 +186,7 @@ def test_packaging_workers():
         # Test watch mode worker creation
         import queue
         result_queue = queue.Queue()
-        watch_worker = WatchModePackagingWorker(logger, keep_originals=False, result_queue)
+        watch_worker = WatchModePackagingWorker(logger, keep_originals=False, result_queue=result_queue)
         assert watch_worker.logger == logger
         assert watch_worker.result_queue == result_queue
         


### PR DESCRIPTION
## Summary
- fix packaging worker loop binding in watch mode
- import is_image_file for watcher validation
- adjust unit test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687eb211ea5883338d72f5c785d9d72f