### PR TITLE
Update stats path to ~/.cbxtools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -236,7 +236,7 @@ Each preset can configure:
 
 ### User Configuration
 - Presets stored in `~/.cbxtools/presets.json`
- - Statistics stored in `~/.cbx-tools-stats.json`
+ - Statistics stored in `~/.cbxtools/.cbx-tools-stats.json`
 - Watch mode history in output directory
 
 ### Debug Parameter Resolution

--- a/cbxtools/cli.py
+++ b/cbxtools/cli.py
@@ -307,7 +307,7 @@ def parse_arguments():
     parser.add_argument('--silent', '-s', action='store_true',
                         help='Suppress all output except errors')
     parser.add_argument('--stats-file', type=str, default=None,
-                        help='Path to stats file (default: ~/.cbx-tools-stats.json)')
+                        help='Path to stats file (default: ~/.cbxtools/.cbx-tools-stats.json)')
     parser.add_argument('--no-stats', action='store_true',
                         help='Do not update or display lifetime statistics')
     parser.add_argument('--stats-only', action='store_true',

--- a/cbxtools/stats_tracker.py
+++ b/cbxtools/stats_tracker.py
@@ -16,7 +16,7 @@ class StatsTracker:
     
     def __init__(self, stats_file=None):
         if stats_file is None:
-            self.stats_file = Path.home() / '.cbxtools//.cbx-tools-stats.json'
+            self.stats_file = Path.home() / '.cbxtools' / '.cbx-tools-stats.json'
         else:
             self.stats_file = Path(stats_file)
         self.stats = self._load_stats()


### PR DESCRIPTION
## Summary
- store stats in `~/.cbxtools/.cbx-tools-stats.json`
- update CLI help message
- document new default in AGENTS.md and README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ebd221fdc8333bbeaad46ac99e7f9